### PR TITLE
ServiceProvider: Throw on *use* without Laravel, instead of throwing on load

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -2,25 +2,30 @@
 
 namespace RecAnalyst\Laravel;
 
-if (!class_exists(\Illuminate\Support\ServiceProvider::class)) {
-    throw new \Exception('Laravel ServiceProvider class not found.');
-}
-
-/**
- * Service provider for use with Laravel.
- */
-class ServiceProvider extends \Illuminate\Support\ServiceProvider
-{
+if (class_exists(\Illuminate\Support\ServiceProvider::class)) {
     /**
-     * Configure translations and image resources.
+     * Service provider for use with Laravel.
      */
-    public function boot()
+    class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
-        $resources = realpath(__DIR__ . '/../../resources');
-        $this->loadTranslationsFrom($resources . '/lang', 'recanalyst');
+        /**
+         * Configure translations and image resources.
+         */
+        public function boot()
+        {
+            $resources = realpath(__DIR__ . '/../../resources');
+            $this->loadTranslationsFrom($resources . '/lang', 'recanalyst');
 
-        $this->publishes([
-            $resources . '/images' => public_path('vendor/recanalyst'),
-        ], 'public');
+            $this->publishes([
+                $resources . '/images' => public_path('vendor/recanalyst'),
+            ], 'public');
+        }
+    }
+} else {
+    class ServiceProvider {
+        public function __construct()
+        {
+            throw new \Exception('Laravel ServiceProvider class not found.');
+        }
     }
 }


### PR DESCRIPTION
With this we could roll up the entire RecAnalyst source into a single file using https://github.com/ClassPreloader/ClassPreloader so it's easier to use without Composer.